### PR TITLE
Workflow to automatically pull Dockerimages monthly

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -1,0 +1,30 @@
+name: deploy
+
+on:
+  schedule:
+    - cron: 0 0 1 * *
+  push:
+    branches:
+      - master
+
+jobs:
+  docker-pull:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull images
+        run: |
+          lastrepo=""
+          lastseen=""
+          for image in $(cat repos.txt); do
+             # Parse repository name, we will remove the previous image if different
+             readarray -d : -t repository <<< "$image"
+             if [ "${lastseen}" != "" ] && [ "${repository[0]}" != "${lastseen}" ]; then
+                 printf "Removing image ${lastseen} to make room."
+                 docker rmi "${lastrepo}" || docker rmi "${lastseen}"
+             fi
+             lastrepo="${repository[0]}"
+             lastseen="${image}"
+             printf "Pulling $image\n";
+             docker pull "${image}"
+          done

--- a/repos.txt
+++ b/repos.txt
@@ -1,0 +1,1 @@
+peerherholz/bidsonym:latest


### PR DESCRIPTION
For any custom container that we build and store on Dockerhub we should include a workflow to pull the image regularly so that it stays available. [Starting Nov. 1st, Dockerhub will remove all images that are not pulled every 6 months.](https://www.docker.com/pricing/retentionfaq). This workflow adds a monthly cron job that will pull all images specified in `repos.txt`